### PR TITLE
feat: minimize statusline elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,11 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 ### Changed
 
 - (**breaking**) Expand customized section content as tmux FORMATS ([#2])
-- (**breaking**) Minimize the entire statusline ([#{{PRNUM}}])
+- (**breaking**) Minimize the entire statusline ([#4])
 
 [#2]: https://github.com/loichyan/tmux-base16/pull/2
 [#3]: https://github.com/loichyan/tmux-base16/pull/3
-[#{{PRNUM}}]: https://github.com/loichyan/tmux-base16/pull/{{PRNUM}}
+[#4]: https://github.com/loichyan/tmux-base16/pull/4
 
 ## [0.1.0] - 2025-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,11 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 ### Changed
 
 - (**breaking**) Expand customized section content as tmux FORMATS ([#2])
+- (**breaking**) Minimize the entire statusline ([#{{PRNUM}}])
 
 [#2]: https://github.com/loichyan/tmux-base16/pull/2
 [#3]: https://github.com/loichyan/tmux-base16/pull/3
+[#{{PRNUM}}]: https://github.com/loichyan/tmux-base16/pull/{{PRNUM}}
 
 ## [0.1.0] - 2025-08-30
 

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ responsible for it value.
 
 ### `@base16-window-{content,current_content}`
 
-**Default**: `##{window_name}##{window_flags}`
+**Default**: `##{window_name}##{window_flags}:##{pane_current_path}`
 
 **Description**: Content displayed in window tabs when `@base16-statusline` is
 enabled. The value is expanded as tmux FORMATS before taking effect.
 
 ### `@base16-status-right-content`
 
-**Default**: `%H:%M  %m-%d %Y`
+**Default**: `%a %H:%M`
 
 **Description**: Content displayed in the right side of the statusline. The
 value is expanded as tmux FORMATS before taking effect.

--- a/src/statusline.conf
+++ b/src/statusline.conf
@@ -4,13 +4,12 @@
 # --- Statusline Configurations ---
 # ---------------------------------
 
+set -gF @base16_mode "#[fg=#{@base16_bg},bg=##{?client_prefix,#{@base0E},#{@base05}}] #[fg=#{@base09},bg=#{@base16_bg}]#[none]"
 set -g  @base16_window_flag "#{||:#{window_activity_flag},#{window_bell_flag},#{window_marked_flag},#{window_silence_flag}}"
-set -gF @base16_window_bg "##{?#{@base16_window_flag},#{@base0A},#{@base01}}"
-set -gF @base16_window_current_bg "#{@base09}"
 
-set -goq @base16-window-content "##{?#{@base16_window_flag},#[bold]##W*#[nobold],##W}"
-set -goq @base16-window-current-content "##W##{?window_zoomed_flag,+,}"
-set -goq @base16-status-right-content "%H:%M  %m-%d %Y"
+set -goq @base16-window-content "##I) ##W##{?#{@base16_window_flag},*}#[fg=#{@base03}]:##{b:pane_current_path}"
+set -goq @base16-window-current-content "#[bold]##I) ##W##{?window_zoomed_flag,+,}#[nobold]#[fg=#{@base03}]:##{b:pane_current_path}"
+set -goq @base16-status-right-content "%a %H:%M |"
 
 set -g status-justify "left"
 set -g status-left-length  "80"
@@ -21,31 +20,20 @@ set -g window-status-separator ""
 # --- Statusline Elements ---
 # ---------------------------
 
-set -g   status-left ""
-set -gaF status-left "##{?client_prefix,#[fg=#{@base00}##,bg=#{@base0E}],#[fg=#{@base16_fg}##,bg=#{@base02}]} #[bold]##S#[nobold] "
-set -gaF status-left "##{?client_prefix,#[fg=#{@base0E}##,bg=#{@base16_bg}],#[fg=#{@base02}##,bg=#{@base16_bg}]}"
+set -gF status-left "#{@base16_mode}"
 
 set -g window-status-bell-style     ""
 set -g window-status-activity-style ""
 
-set -g   window-status-format ""
-set -gaF window-status-format "#[fg=#{@base16_window_bg},bg=#{@base16_bg}]#[reverse]#[noreverse]"
-set -gaF window-status-format "#[fg=#{@base04},bg=#{@base16_window_bg}] ##I  #{E:@base16-window-content} "
-set -gaF window-status-format "#[fg=#{@base16_window_bg},bg=#{@base16_bg}]"
-
-set -g   window-status-current-format ""
-set -gaF window-status-current-format "#[fg=#{@base16_window_current_bg},bg=#{@base16_bg}]#[reverse]#[noreverse]"
-set -gaF window-status-current-format "#[fg=#{@base02},bg=#{@base16_window_current_bg}] ##I  #[bold]#{E:@base16-window-current-content}#[nobold] "
-set -gaF window-status-current-format "#[fg=#{@base16_window_current_bg},bg=#{@base16_bg}]"
+set -gF window-status-format "#[fg=##{?#{@base16_window_flag},#{@base16_fg},#{@base04}},bg=#{@base16_bg}] #{E:@base16-window-content}#[none] "
+set -gF window-status-current-format "#[fg=#{@base0A},bg=#{@base16_bg}] #{E:@base16-window-current-content}#[none] "
 
 set -g   status-right ""
-set -gaF status-right "#[fg=#{@base01},bg=#{@base16_bg}]"
-set -gaF status-right "#[fg=#{@base04},bg=#{@base01}] #{E:@base16-status-right-content} "
-set -gaF status-right "#[fg=#{@base02},bg=#{@base01}]"
-set -gaF status-right "#[fg=#{@base16_fg},bg=#{@base02}] #[bold]##h#[nobold] "
+set -gaF status-right "#[fg=#{@base04},bg=#{@base16_bg}]#{E:@base16-status-right-content}#[none] "
+set -gaF status-right "#[fg=#{@base09},bg=#{@base16_bg}]#[bold]##S#[none] "
+set -gaF status-right "#{@base16_mode}"
 
+set -gu @base16_mode
 set -gu @base16_window_flag
-set -gu @base16_window_bg
-set -gu @base16_window_current_bg
 
 # vim:ft=tmux

--- a/src/statusline.conf
+++ b/src/statusline.conf
@@ -29,7 +29,7 @@ set -gF window-status-format "#[fg=##{?#{@base16_window_flag},#{@base16_fg},#{@b
 set -gF window-status-current-format "#[fg=#{@base0A},bg=#{@base16_bg}] #{E:@base16-window-current-content}#[none] "
 
 set -g   status-right ""
-set -gaF status-right "#[fg=#{@base04},bg=#{@base16_bg}]#{E:@base16-status-right-content}#[none] "
+set -gaF status-right "#[fg=#{@base03},bg=#{@base16_bg}]#{E:@base16-status-right-content}#[none] "
 set -gaF status-right "#[fg=#{@base09},bg=#{@base16_bg}]#[bold]##S#[none] "
 set -gaF status-right "#{@base16_mode}"
 


### PR DESCRIPTION
Refine the entire the statusline to match a minimalist style. The new design is inspired by a [post](https://www.reddit.com/r/tmux/comments/1n4mkgn/most_minimalist_status_line_for_tmux_that_i/) on Reddit.

Before:

![Screenshot From 2025-09-02 18-39-16](https://github.com/user-attachments/assets/ef01d352-3949-4621-878f-59171d265f7e)

After:


![Screenshot From 2025-09-02 18-52-19](https://github.com/user-attachments/assets/43792043-918a-4f4b-b9b3-694edf8cb809)

