### PR TITLE
feat: support rendering templates in batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,9 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ### Added
 
-- Support rendering templates in batch ([#{{PRNUM}}])
+- Support rendering templates in batch ([#8])
 
-[#{{PRNUM}}]: https://github.com/loichyan/tmux-base16/pull/{{PRNUM}}
+[#8]: https://github.com/loichyan/tmux-base16/pull/8
 
 ## [0.2.1] - 2026-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ## [Unreleased]
 
+### Added
+
+- Support rendering templates in batch ([#{{PRNUM}}])
+
+[#{{PRNUM}}]: https://github.com/loichyan/tmux-base16/pull/{{PRNUM}}
+
 ## [0.2.1] - 2026-02-26
 
 ### Added

--- a/src/build_palette.py
+++ b/src/build_palette.py
@@ -239,11 +239,15 @@ def parse_args() -> argparse.Namespace:
         "-i",
         "--input",
         required=True,
+        action="append",
+        default=[],
         help="path to input template",
     )
     parser.add_argument(
         "-o",
         "--output",
+        action="append",
+        default=[],
         help="path to write output",
     )
     return parser.parse_args()
@@ -263,15 +267,21 @@ def main():
         config = parse_config(parser)
     config.current = getattr(config, args.current)
 
-    with open(args.input, "r") as f:
-        input = f.read()
+    if len(args.input) != len(args.output) and len(args.output) != 0:
+        raise ValueError("number of output paths must exactly match that of input")
 
-    output = render_template(config, input)
-    if args.output is not None:
-        with open(args.output, "w") as f:
+    outpath_iter = iter(args.output)
+    for inpath in args.input:
+        with open(inpath, "r") as f:
+            input = f.read()
+        output = render_template(config, input)
+        outpath = next(outpath_iter, None)
+
+        if outpath is None:
+            print(output)
+            continue
+        with open(outpath, "w") as f:
             f.write(output)
-    else:
-        print(output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make `@base16-build-palette` support multiple `--input` and `--output` to avoid redundant configuration parsing when rendering multiple templates.

Before:

```sh
tmux run '#{@base16-build-palette} -i "#{@base16-templates}/foot.ini" -o ~/.config/foot/colors.ini'
tmux run '#{@base16-build-palette} -i "#{@base16-templates}/alacritty.toml" -o ~/.config/alacritty/colors.toml'
```

After:

```sh
tmux run '#{@base16-build-palette} \
    -i "#{@base16-templates}/foot.ini" -o ~/.config/foot/colors.ini \
    -i "#{@base16-templates}/alacritty.toml" -o ~/.config/alacritty/colors.toml'
```